### PR TITLE
Change image to text from varchar

### DIFF
--- a/www/docs/schemas/postgres.md
+++ b/www/docs/schemas/postgres.md
@@ -46,7 +46,7 @@ CREATE TABLE users
     name           VARCHAR(255),
     email          VARCHAR(255),
     email_verified TIMESTAMPTZ,
-    image          VARCHAR(255),
+    image          TEXT,
     created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id)


### PR DESCRIPTION
I got an error earlier today because someone with a Google account had an image URL longer than 255 characters. My understanding is that there isn't much of a reason to use `varchar` over `text` anyway, so I'm changing this to just use `text`.

I just changed the one place where I got an error – not sure if it's worth changing the others. Also I'm less familiar with the other databases but it's possible they should be updated as well. 